### PR TITLE
Increase aggression in removing sensitive data

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Nicholas Pilon 
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyramid_crow/__init__.py
+++ b/pyramid_crow/__init__.py
@@ -85,7 +85,7 @@ def raven_client(request):
     adds to client's context"""
     kwargs = {
         'processors': (
-            'raven.processors.SanitizePasswordsProcessor',
+            'pyramid_crow.processors.PyramidSanitizePasswordsProcessor',
         ),
         'timeout': 4,
     }

--- a/pyramid_crow/processors.py
+++ b/pyramid_crow/processors.py
@@ -1,0 +1,46 @@
+from functools import partial
+
+from raven._compat import string_types
+from raven.processors import SanitizePasswordsProcessor
+from raven.utils import varmap
+
+
+class PyramidSanitizePasswordsProcessor(SanitizePasswordsProcessor):
+    """Do some extra sanitization to pick up places where pyramid tends to
+    leak passwords through"""
+
+    def sensitive_repr_filter(self, key, value):
+        for field in self.FIELDS:
+            if isinstance(value, string_types) and field + '=' in value:
+                return '[Filtered]'
+
+        return value
+
+    def filter_stacktrace(self, data):
+        """Filter out any local variables that contain sensitive-looking
+        patterns in their repr()s"""
+        super(PyramidSanitizePasswordsProcessor, self).filter_stacktrace(data)
+        for frame in data.get('frames', []):
+            if 'vars' not in frame:
+                continue
+
+            frame['vars'] = varmap(self.sensitive_repr_filter, frame['vars'])
+
+    def filter_http(self, data):
+        """Also descend into env, headers looking for keyval-ish strings"""
+        super(PyramidSanitizePasswordsProcessor, self).filter_http(data)
+        for n in ('headers', 'env'):
+            if isinstance(data[n], dict):
+                data[n] = varmap(
+                    partial(self.vm_sanitize_keyval, delimiter='&'),
+                    data[n],
+                )
+
+    def vm_sanitize_keyval(self, key, keyval, delimiter):
+        """varmap-friendly way to call _sanitize_keyvals
+
+        Also handles mixed types in env"""
+        if isinstance(keyval, string_types):
+            return self._sanitize_keyvals(keyval, delimiter)
+        else:
+            return keyval

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.2'
+version = '0.2.1'
 
 setup(name='pyramid_crow',
       version=version,


### PR DESCRIPTION
Pyramid can leak sensitive data through common repr()s in locals; look
for and remove these, and also clean up env better.
