### PR TITLE
Change raven client to be global

### DIFF
--- a/pyramid_crow/__init__.py
+++ b/pyramid_crow/__init__.py
@@ -24,8 +24,6 @@ if PY3: # pragma: no cover
 else:
     import __builtin__ as builtins
 
-CLEAR_CONTEXT_FLAG = "pyramid_crow.clear"
-
 
 def as_globals_list(value):
     L = []
@@ -87,11 +85,13 @@ def _request_to_http_context(request):
     }
 
 
+def _raven_clear_context(r):
+    r.raven.context.clear()
+
+
 def _raven(request):
     client = request.registry["raven.client"]
-    clear_after = request.environ.get(CLEAR_CONTEXT_FLAG, True)
-    if clear_after:
-        request.add_finished_callback(lambda r: r.raven.context.clear())
+    request.add_finished_callback(_raven_clear_context)
     return client
 
 

--- a/pyramid_crow/__init__.py
+++ b/pyramid_crow/__init__.py
@@ -90,7 +90,6 @@ def _request_to_http_context(request):
 def _raven(request):
     client = request.registry["raven.client"]
     clear_after = request.environ.get(CLEAR_CONTEXT_FLAG, True)
-    client.http_context(_request_to_http_context(request))
     if clear_after:
         request.add_finished_callback(lambda r: r.raven.context.clear())
     return client

--- a/pyramid_crow/tests.py
+++ b/pyramid_crow/tests.py
@@ -100,12 +100,12 @@ class TestIntegration(unittest.TestCase):
 
         app = self._makeApp()
 
-        with mock.patch.object(pyramid_crow.Client,
-                               'captureException') as mock_capture:
-            self.assertRaises(ExpectedException, app.get, '/',
-                              extra_environ={
-                                  pyramid_crow.CLEAR_CONTEXT_FLAG: False
-                              })
+        with mock.patch.object(
+            pyramid_crow.Client, 'captureException'
+        ) as mock_capture, mock.patch(
+            'pyramid_crow._raven_clear_context', new=(lambda r: r)
+        ):
+            self.assertRaises(ExpectedException, app.get, '/')
 
         mock_capture.assert_called_once()
         self.assertEqual(
@@ -136,13 +136,14 @@ class TestIntegration(unittest.TestCase):
 
         app = self._makeApp()
 
-        with mock.patch.object(pyramid_crow.Client,
-                               'captureException') as mock_capture:
+        with mock.patch.object(
+            pyramid_crow.Client, 'captureException'
+        ) as mock_capture, mock.patch(
+            'pyramid_crow._raven_clear_context', new=(lambda r: r)
+        ):
             self.assertRaises(ExpectedException, app.get, '/',
-                              params=(('foo', 'bar'), ('baz', 'garply')),
-                              extra_environ={
-                                  pyramid_crow.CLEAR_CONTEXT_FLAG: False
-                              })
+                              params=(('foo', 'bar'), ('baz', 'garply'))
+                              )
 
         mock_capture.assert_called_once()
         self.assertEqual(
@@ -193,13 +194,14 @@ class TestIntegration(unittest.TestCase):
 
         app = self._makeApp()
 
-        with mock.patch.object(pyramid_crow.Client,
-                               'captureException') as mock_capture:
+        with mock.patch.object(
+            pyramid_crow.Client, 'captureException'
+        ) as mock_capture, mock.patch(
+            'pyramid_crow._raven_clear_context', new=(lambda r: r)
+        ):
             self.assertRaises(ExpectedException, app.post, '/',
-                              params=(('foo', 'bar'), ('baz', 'garply')),
-                              extra_environ={
-                                  pyramid_crow.CLEAR_CONTEXT_FLAG: False
-                              })
+                              params=(('foo', 'bar'), ('baz', 'garply'))
+                              )
 
         mock_capture.assert_called_once()
         self.assertEqual(


### PR DESCRIPTION
Creating a raven client per request leaks threads after every exception sent.
